### PR TITLE
Fix OSM type parser

### DIFF
--- a/app/Models/Spring.php
+++ b/app/Models/Spring.php
@@ -95,7 +95,7 @@ class Spring extends Model
         if (count(
             $this->osm_tags->filter(function($item) {
                 return $item->key == 'natural' &&
-                    ($item->value == 'spring' | $item->value == 'spring_box');
+                    ($item->value == 'spring' || $item->value == 'spring_box');
             }))) {
             return 'Spring';
         }


### PR DESCRIPTION
## Summary
- correct logical operator when parsing OSM spring type

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401fe25e34832fbb0453c296cabe3f